### PR TITLE
fix/ Valori non corretti nella lista dei Guest

### DIFF
--- a/src/pages/speakers/index.astro
+++ b/src/pages/speakers/index.astro
@@ -82,6 +82,7 @@ const coHosts = getCoHosts();
             <a href="https://github.com/JellyBellyDev" class="underline text-slate-700">Andrea Giannantonio</a>
             <a href="https://github.com/fsgreco" class="underline text-slate-700">Santiago (fsgreco)</a>
             <a href="https://github.com/EmanueleGurini" class="underline text-slate-700">Emanuele Gurini</a>
+            <a href="https://github.com/NuclearManatee" class="underline text-slate-700">Edoardo Cremaschi</a>
           </p>
         </div>
       </div>

--- a/src/pages/speakers/index.astro
+++ b/src/pages/speakers/index.astro
@@ -3,7 +3,7 @@ import { Image } from "@astrojs/image/components";
 import BackButton from "../../components/BackButton.astro";
 import Menu from "../../components/Menu.astro";
 import Layout from "../../layouts/Layout.astro";
-import { buildTitle, getCoHosts, getPodcastFeed, getSlug } from "../../utils";
+import { buildTitle, getCoHosts, getPodcastFeed, getSlug, getGuestName } from "../../utils";
 const { episodes } = await getPodcastFeed(
   "https://www.spreaker.com/show/4173756/episodes/feed"
 );
@@ -59,14 +59,14 @@ const coHosts = getCoHosts();
           <div class="grid grid-cols-2 my-4">
             {
               episodes.map((e) => {
-                const guest = e.title.split("con ")?.[1];
+                const name = getGuestName(e);
                 return (
-                  guest && (
+                  name && (
                     <a
                       class=" block m-1 px-2 py-1 text-sm text-slate-700 bg-slate-50 rounded leading-relaxed"
                       href={"/episodes/" + getSlug(e)}
                     >
-                      {guest}
+                      {name}
                     </a>
                   )
                 );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,3 +132,13 @@ export const getCoHosts = () => {
     },
   ];
 };
+
+export const getGuestName = (e : Episode) => {
+
+  const split : string = e.title.split("con ")?.[1];
+
+  return split?.match('[A-Z]{1}[a-z]* [A-Z]{1}[a-z]* \(.*\)')?.[0] ?
+    split?.match('[A-Z]{1}[a-z]* [A-Z]{1}[a-z]* \(.*\)')?.[0] :
+    split?.match('[A-Z]{1}[a-z]* [A-Z]{1}[a-z]*')?.[0];
+
+};


### PR DESCRIPTION
I applied some regex to pattern match strings like `${fistName} ${lastName}` or `${firstName} ${lastName} (${company})`.
It doesn't apply perfectly with all the cases, especially with the old episodes.

closes #27 