### PR TITLE
feat: split episodes list in paginated pages

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  currentPage: number;
+  pages: Array<{
+    link: string;
+  }>
+}
+
+const {currentPage, pages} = Astro.props;
+---
+
+
+<div class="flex items-center justify-center px-4 py-4 sm:px-6">
+  <nav class="isolate inline-flex -space-x-px rounded-md shadow-sm" aria-label="Pagination">
+    {currentPage > 1 ? <a href={pages[currentPage - 2].link} class="relative inline-flex items-center rounded-l-md border border-slate-800 px-2 py-2 text-sm font-medium text-gray-500 hover:bg-yellow-400 focus:z-20">
+      <span class="sr-only">Pagina precedente</span>
+      <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
+      </svg>
+    </a> : null}
+    {
+      pages.map((page, index) => (
+        <a
+          href={page.link}
+          aria-current={(index + 1) === currentPage ? "page" : undefined}
+          class={`relative hidden items-center border  px-4 py-2 text-sm font-medium hover:bg-yellow-400 focus:z-20 md:inline-flex border-slate-800 text-slate-800 ${(index + 1) === currentPage ? 'bg-yellow-400' : ''}`}
+        >{index + 1}</a>
+      ))
+    }
+
+    {currentPage < pages.length ? <a href={pages[currentPage].link} class="relative inline-flex items-center rounded-r-md border border-slate-800 px-2 py-2 text-sm font-medium text-slate-800 hover:bg-yellow-400 focus:z-20">
+      <span class="sr-only">Pagina successiva</span>
+      <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+      </svg>
+    </a> : null}
+  </nav>
+</div>

--- a/src/pages/episodes/[page].astro
+++ b/src/pages/episodes/[page].astro
@@ -2,8 +2,8 @@
 import Layout from "../../layouts/Layout.astro";
 import {
   getPodcastFeed,
-  episodePages2Urls,
-buildTitle,
+  buildTitle,
+  episodePagination,
 } from "../../utils";
 import Menu from "../../components/Menu.astro";
 import Search from "../../components/search";
@@ -15,20 +15,20 @@ export async function getStaticPaths() {
     "https://www.spreaker.com/show/4173756/episodes/feed"
   );
 
-  const pages = Math.ceil(episodes.length / 20);
+  const pagination = episodePagination(episodes);
 
-  return episodePages2Urls(pages).map((url, index) => ({
-    params: {page: url},
+  return pagination.pages.map((page, index) => ({
+    params: {page: page.param},
     props: {
       episodes: episodes.slice(20 * index, 20 * (index +1)),
-      pages,
+      pagination,
       currentPage: index + 1
     }
   }));
 }
 
-const { episodes, pages, currentPage } = Astro.props;
-const {page} = Astro.params;
+const { episodes, currentPage, pagination } = Astro.props;
+const { page } = Astro.params;
 ---
 
 <Layout
@@ -49,8 +49,6 @@ const {page} = Astro.params;
       {episodes.map((e) => <EpisodeCard {...e} />)}
     </ul>
 
-    <Pagination currentPage={currentPage} pages={episodePages2Urls(pages).map((url) => ({
-      link: `/episodes/${url}`
-    }))} />
+    <Pagination currentPage={currentPage} pages={pagination.pages} />
   </main>
 </Layout>

--- a/src/pages/episodes/[page].astro
+++ b/src/pages/episodes/[page].astro
@@ -1,0 +1,56 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import {
+  getPodcastFeed,
+  episodePages2Urls,
+buildTitle,
+} from "../../utils";
+import Menu from "../../components/Menu.astro";
+import Search from "../../components/search";
+import EpisodeCard from "../../components/EpisodeCard.astro";
+import Pagination from "../../components/Pagination.astro";
+
+export async function getStaticPaths() {
+  const { episodes } = await getPodcastFeed(
+    "https://www.spreaker.com/show/4173756/episodes/feed"
+  );
+
+  const pages = Math.ceil(episodes.length / 20);
+
+  return episodePages2Urls(pages).map((url, index) => ({
+    params: {page: url},
+    props: {
+      episodes: episodes.slice(20 * index, 20 * (index +1)),
+      pages,
+      currentPage: index + 1
+    }
+  }));
+}
+
+const { episodes, pages, currentPage } = Astro.props;
+const {page} = Astro.params;
+---
+
+<Layout
+  seo={{
+    canonical: page === 'page-1' ? '/' : `/episodes/${page}`,
+    title: buildTitle('Tutti gli episodi - Pagina ' + currentPage),
+    description: 'Gitbar è il podcast per sviluppatori italiani dedicato alla programmazione e allo sviluppo web. Ogni giovedì un nuovo argomento con brainrepo.',
+    image: '/mauro.png',
+  }}
+>
+  <main class="relative lg:min-h-screen flex flex-col">
+    <Menu />
+    <Search client:load />
+    <ul
+      role="list"
+      class="max-w-4xl 4xl:max-w-7xl mx-auto w-full p-2 sm:p-4 md:p-8 lg:p-8 grid 4xl:grid-cols-2 gap-2"
+    >
+      {episodes.map((e) => <EpisodeCard {...e} />)}
+    </ul>
+
+    <Pagination currentPage={currentPage} pages={episodePages2Urls(pages).map((url) => ({
+      link: `/episodes/${url}`
+    }))} />
+  </main>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,17 +5,16 @@ import Menu from "../components/Menu.astro";
 import Pagination from "../components/Pagination.astro";
 import Search from "../components/search";
 import Layout from "../layouts/Layout.astro";
-import { getPodcastFeed, episodePages2Urls } from "../utils";
+import { getPodcastFeed, episodePagination } from "../utils";
 
 const data = await getPodcastFeed(
   "https://www.spreaker.com/show/4173756/episodes/feed"
 )
 
-const pages = Math.ceil(data.episodes.length / 20);
-
 const title = "Gitbar - Il podcast dei developer italiani"
 const description = "Gitbar è il podcast per sviluppatori italiani dedicato alla programmazione e allo sviluppo web. Ogni giovedì un nuovo argomento con brainrepo."
 
+const pagination = episodePagination(data.episodes);
 ---
 
 <Layout seo={{ title, description, image: "/mauro.png" }}>
@@ -29,8 +28,6 @@ const description = "Gitbar è il podcast per sviluppatori italiani dedicato all
       {data.episodes.slice(0, 20).map((e) => <EpisodeCard {...e} />)}
     </ul>
 
-    <Pagination currentPage={1} pages={episodePages2Urls(pages).map((url) => ({
-      link: `/episodes/${url}`
-    }))} />
+    <Pagination currentPage={1} pages={pagination.pages} />
   </main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,13 +2,16 @@
 import EpisodeCard from "../components/EpisodeCard.astro";
 import Hosts from "../components/Hosts.astro";
 import Menu from "../components/Menu.astro";
+import Pagination from "../components/Pagination.astro";
 import Search from "../components/search";
 import Layout from "../layouts/Layout.astro";
-import { getPodcastFeed } from "../utils";
+import { getPodcastFeed, episodePages2Urls } from "../utils";
 
 const data = await getPodcastFeed(
   "https://www.spreaker.com/show/4173756/episodes/feed"
 )
+
+const pages = Math.ceil(data.episodes.length / 20);
 
 const title = "Gitbar - Il podcast dei developer italiani"
 const description = "Gitbar è il podcast per sviluppatori italiani dedicato alla programmazione e allo sviluppo web. Ogni giovedì un nuovo argomento con brainrepo."
@@ -23,7 +26,11 @@ const description = "Gitbar è il podcast per sviluppatori italiani dedicato all
       role="list"
       class="max-w-4xl 4xl:max-w-7xl mx-auto w-full p-2 sm:p-4 md:p-8 lg:p-8 grid 4xl:grid-cols-2 gap-2"
     >
-      {data.episodes.map((e) => <EpisodeCard {...e} />)}
+      {data.episodes.slice(0, 20).map((e) => <EpisodeCard {...e} />)}
     </ul>
+
+    <Pagination currentPage={1} pages={episodePages2Urls(pages).map((url) => ({
+      link: `/episodes/${url}`
+    }))} />
   </main>
 </Layout>

--- a/src/pages/speakers/index.astro
+++ b/src/pages/speakers/index.astro
@@ -84,6 +84,7 @@ const coHosts = getCoHosts();
             <a href="https://github.com/EmanueleGurini" class="underline text-slate-700">Emanuele Gurini</a>
             <a href="https://github.com/SamSalvatico" class="underline text-slate-700">Samuele Salvatico</a>
             <a href="https://github.com/NuclearManatee" class="underline text-slate-700">Edoardo Cremaschi</a>
+            <a href="https://github.com/Takeno" class="underline text-slate-700">Matteo Manchi</a>
           </p>
         </div>
       </div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,3 +142,7 @@ export const getGuestName = (e : Episode) => {
     split?.match('[A-Z]{1}[a-z]* [A-Z]{1}[a-z]*')?.[0];
 
 };
+
+export function episodePages2Urls (pages:number) {
+  return (new Array(pages)).fill(0).map((_, index) => `page-${index + 1}`);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,3 +146,16 @@ export const getGuestName = (e : Episode) => {
 export function episodePages2Urls (pages:number) {
   return (new Array(pages)).fill(0).map((_, index) => `page-${index + 1}`);
 }
+
+
+const EPISODES_PER_PAGE = 20;
+
+export function episodePagination(episodes: Episode[]) {
+  const numberOfPages = Math.ceil(episodes.length / EPISODES_PER_PAGE);
+  const pages = (new Array(numberOfPages)).fill(0).map((_, index) => ({
+    param: `page-${index + 1}`,
+    link: `/episodes/page-${index + 1}`
+  }))
+
+  return {numberOfPages, pages};
+}


### PR DESCRIPTION
<img width="884" alt="immagine" src="https://user-images.githubusercontent.com/1499063/206715617-9bd88c31-869d-48bf-b820-d7c70525612b.png">

Tagliato l'elenco degli episodi in home page, introducendo una paginazione a 20 elementi.

index.html scende da 312KB (39KB gzipped) a 58KB (10.4KB gzipped).

In questo modo risolviamo il principale problema di performance evidenziato da Lighthouse:
<img width="704" alt="immagine" src="https://user-images.githubusercontent.com/1499063/206719901-e43b50d8-1ace-4eb0-8556-082931a0c2c9.png">



Related to #29 
